### PR TITLE
Use $(SERVER_BIN) instead of $SERVER_BIN in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,7 @@ check: ## Concurrently runs a whole bunch of static analysis tools
 
 .PHONY: run
 run: build ## runs the service locally
-	$SERVER_BIN
+	$(SERVER_BIN)
 
 .PHONY: tools
 tools: ## Installs all necessary tools


### PR DESCRIPTION
Fixes https://github.com/fabric8-services/build-tool-detector/issues/9