### PR TITLE
Fix typo: sebtry => sentry

### DIFF
--- a/config-template.yml
+++ b/config-template.yml
@@ -20,7 +20,7 @@ github:
 #-----------------------
 # Sentry Authentication \
 #------------------------------------------------------------------------------
-# This section defines sebtry authentication
+# This section defines sentry authentication
 sentry:
     dsn: ""
 


### PR DESCRIPTION
Change `sebtry` to `sentry` in `config-template.yml` file