### PR TITLE
Use golang from epel repo

### DIFF
--- a/.make/docker.mk
+++ b/.make/docker.mk
@@ -22,6 +22,7 @@ DOCKER_BUILD_DIR := $(WORKSPACE)/$(PROJECT_NAME)-build
 # to reflect jenkins-${JOB_NAME}-${BUILD_NUMBER}
 BUILD_TAG ?= $(PROJECT_NAME)-local-build
 DOCKER_CONTAINER_NAME := $(BUILD_TAG)
+USE_GO_VERSION_FROM_WEBSITE ?= 1
 
 # Where is the GOPATH inside the build container?
 GOPATH_IN_CONTAINER=/tmp/go

--- a/.make/docker.mk
+++ b/.make/docker.mk
@@ -22,7 +22,6 @@ DOCKER_BUILD_DIR := $(WORKSPACE)/$(PROJECT_NAME)-build
 # to reflect jenkins-${JOB_NAME}-${BUILD_NUMBER}
 BUILD_TAG ?= $(PROJECT_NAME)-local-build
 DOCKER_CONTAINER_NAME := $(BUILD_TAG)
-USE_GO_VERSION_FROM_WEBSITE ?= 1
 
 # Where is the GOPATH inside the build container?
 GOPATH_IN_CONTAINER=/tmp/go

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -2,7 +2,7 @@ FROM centos:7
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Konrad Kleine <kkleine@redhat.com>"
 ENV LANG=en_US.utf8
-ARG USE_GO_VERSION_FROM_WEBSITE=0
+ARG USE_GO_VERSION_FROM_WEBSITE=1
 
 # Some packages might seem weird but they are required by the RVM installer.
 RUN yum install epel-release -y && \

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -2,11 +2,11 @@ FROM centos:7
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Konrad Kleine <kkleine@redhat.com>"
 ENV LANG=en_US.utf8
-ARG USE_GO_VERSION_FROM_WEBSITE=1
+ARG USE_GO_VERSION_FROM_WEBSITE
 
 # Some packages might seem weird but they are required by the RVM installer.
 RUN yum install epel-release -y && \
-    yum --enablerepo=centosplus --enablerepo=epel install -y --quiet\
+    yum --enablerepo=centosplus --enablerepo=epel install -y \
       findutils \
       git \
       $(test "$USE_GO_VERSION_FROM_WEBSITE" != 1  && echo "golang") \

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -2,7 +2,7 @@ FROM centos:7
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Konrad Kleine <kkleine@redhat.com>"
 ENV LANG=en_US.utf8
-ARG USE_GO_VERSION_FROM_WEBSITE
+ARG USE_GO_VERSION_FROM_WEBSITE=0
 
 # Some packages might seem weird but they are required by the RVM installer.
 RUN yum install epel-release -y && \
@@ -17,12 +17,13 @@ RUN yum install epel-release -y && \
       which \
     && yum clean all
 
-RUN if [[ "$USE_GO_VERSION_FROM_WEBSITE" = 1 ]]; then cd /tmp \
-    && wget https://dl.google.com/go/go1.10.linux-amd64.tar.gz \
-    && echo "b5a64335f1490277b585832d1f6c7f8c6c11206cba5cd3f771dcb87b98ad1a33  go1.10.linux-amd64.tar.gz" > checksum \
+RUN echo $USE_GO_VERSION_FROM_WEBSITE
+RUN if [[ "$USE_GO_VERSION_FROM_WEBSITE" == 1 ]]; then cd /tmp \
+    && wget https://dl.google.com/go/go1.11.3.linux-amd64.tar.gz \
+    && echo "b5a64335f1490277b585832d1f6c7f8c6c11206cba5cd3f771dcb87b98ad1a33  go1.11.3.linux-amd64.tar.gz" > checksum \
     && sha256sum -c checksum \
-    && tar -C /usr/local -xzf go1.10.linux-amd64.tar.gz \
-    && rm -f go1.10.linux-amd64.tar.gz; \
+    && tar -C /usr/local -xzf go1.11.3.linux-amd64.tar.gz \
+    && rm -f go1.11.3.linux-amd64.tar.gz; \
     fi
 ENV PATH=$PATH:/usr/local/go/bin
 

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -5,10 +5,11 @@ ENV LANG=en_US.utf8
 ARG USE_GO_VERSION_FROM_WEBSITE=0
 
 # Some packages might seem weird but they are required by the RVM installer.
-RUN yum --enablerepo=centosplus install -y --quiet \
+RUN yum install epel-release -y && \
+    yum --enablerepo=centosplus --enablerepo=epel install -y --quiet\
       findutils \
       git \
-      $(test -z $USE_GO_VERSION_FROM_WEBSITE && echo "golang") \
+      $(test "$USE_GO_VERSION_FROM_WEBSITE" != 1  && echo "golang") \
       make \
       procps-ng \
       tar \
@@ -16,13 +17,13 @@ RUN yum --enablerepo=centosplus install -y --quiet \
       which \
     && yum clean all
 
-RUN test -n $USE_GO_VERSION_FROM_WEBSITE \
-    && cd /tmp \
+RUN if [[ "$USE_GO_VERSION_FROM_WEBSITE" = 1 ]]; then cd /tmp \
     && wget https://dl.google.com/go/go1.10.linux-amd64.tar.gz \
     && echo "b5a64335f1490277b585832d1f6c7f8c6c11206cba5cd3f771dcb87b98ad1a33  go1.10.linux-amd64.tar.gz" > checksum \
     && sha256sum -c checksum \
     && tar -C /usr/local -xzf go1.10.linux-amd64.tar.gz \
-    && rm -f go1.10.linux-amd64.tar.gz
+    && rm -f go1.10.linux-amd64.tar.gz; \
+    fi
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Get dep for Go package management and make sure the directory has full rwz permissions for non-root users

--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,15 @@ SOURCES := $(shell find $(SOURCE_DIR) -path $(SOURCE_DIR)/vendor -prune -o -name
 DESIGN_DIR=design
 DESIGNS := $(shell find $(SOURCE_DIR)/$(DESIGN_DIR) -path $(SOURCE_DIR)/vendor -prune -o -name '*.go' -print)
 
+# This pattern excludes the listed folders while running tests
+TEST_PKGS_EXCLUDE_PATTERN = "vendor\|app$\|tool\/build-tool-detector-cli\|design\|client\|test"
+
 include ./.make/docker.mk
 ifeq ($(OS),Windows_NT)
 include ./.make/Makefile.win
 else
 include ./.make/Makefile.lnx
 endif
-
-
-
 
 # This is a fix for a non-existing user in passwd file when running in a docker
 # container and trying to clone repos of dependencies
@@ -177,7 +177,8 @@ generate: prebuild-check $(DESIGNS) $(GOAGEN_BIN) $(VENDOR_DIR) ## Generate GOA 
 	
 .PHONY: test 
 test: test-deps  ## Executes all tests
-	$(GINKGO_BIN) -r
+	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(TEST_PKGS_EXCLUDE_PATTERN)))
+	go test -vet off $(TEST_PACKAGES) -v
 
 .PHONY: format ## Removes unneeded imports and formats source code
 format: 

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ generate: prebuild-check $(DESIGNS) $(GOAGEN_BIN) $(VENDOR_DIR) ## Generate GOA 
 	
 .PHONY: test 
 test: test-deps  ## Executes all tests
-	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(TEST_PKGS_EXCLUDE_PATTERN)))
+	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v -E $(TEST_PKGS_EXCLUDE_PATTERN)))
 	go test -vet off $(TEST_PACKAGES) -v
 
 .PHONY: format ## Removes unneeded imports and formats source code

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DESIGN_DIR=design
 DESIGNS := $(shell find $(SOURCE_DIR)/$(DESIGN_DIR) -path $(SOURCE_DIR)/vendor -prune -o -name '*.go' -print)
 
 # This pattern excludes the listed folders while running tests
-TEST_PKGS_EXCLUDE_PATTERN = "vendor\|app$\|tool\/build-tool-detector-cli\|design\|client\|test"
+TEST_PKGS_EXCLUDE_PATTERN = "vendor|app|tool\/build-tool-detector-cli|design|client|test"
 
 include ./.make/docker.mk
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
See https://github.com/openshiftio/openshift.io/issues/4618

With this PR, we will install golang from the website but we also support installing golang from `epel (stable)` repo.